### PR TITLE
Backport to Java 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,9 +21,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>17.0</version>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.0</version>
         </dependency>
     </dependencies>
 
@@ -35,9 +35,9 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.1</version>
                     <configuration>
-                        <compilerVersion>1.6</compilerVersion>
-                        <source>1.8</source>
-                        <target>1.8</target>
+                        <compilerVersion>1.7</compilerVersion>
+                        <source>1.7</source>
+                        <target>1.7</target>
                         <compilerArgument>-Xlint:all</compilerArgument>
                         <showWarnings>true</showWarnings>
                         <showDeprecation>true</showDeprecation>

--- a/src/main/java/io/dmitryivanov/crdt/GSet.java
+++ b/src/main/java/io/dmitryivanov/crdt/GSet.java
@@ -24,10 +24,11 @@
 
 package io.dmitryivanov.crdt;
 
+import io.dmitryivanov.crdt.helpers.Operations;
+
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public class GSet<E> {
 
@@ -56,8 +57,7 @@ public class GSet<E> {
     }
 
     public GSet<E> diff(GSet<E> anotherGSet) {
-        final Set<E> anotherSetLookup = anotherGSet.lookup();
-        return new GSet<>(this.set.stream().filter(e -> !anotherSetLookup.contains(e)).collect(Collectors.toSet()));
+        return new GSet<>(Operations.diff(set, anotherGSet.lookup()));
     }
 
     // Visible for testing

--- a/src/main/java/io/dmitryivanov/crdt/ORSet.java
+++ b/src/main/java/io/dmitryivanov/crdt/ORSet.java
@@ -24,8 +24,9 @@
 
 package io.dmitryivanov.crdt;
 
+import io.dmitryivanov.crdt.helpers.Operations;
+
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public class ORSet<E> {
 
@@ -95,14 +96,28 @@ public class ORSet<E> {
     }
 
     public Set<E> lookup() {
-        return addSet.lookup().stream().filter(this::nonRemoved).map(ElementState::getElement).collect(Collectors.toSet());
+        return Operations.filteredAndMapped(addSet.lookup(), new Operations.Predicate<ElementState<E>>() {
+            @Override
+            public boolean call(ElementState<E> element) {
+                return nonRemoved(element);
+            }
+        }, new Operations.Mapper<ElementState<E>, E>() {
+            @Override
+            public E call(ElementState<E> element) {
+                return element.element;
+            }
+        });
     }
 
-    private boolean nonRemoved(ElementState<E> addState) {
-        Set<ElementState<E>> removes =
-                removeSet.lookup().stream()
-                        .filter(removeState -> removeState.getElement().equals(addState.getElement())
-                                && removeState.getTag().equals(addState.getTag())).collect(Collectors.toSet());
+    private boolean nonRemoved(final ElementState<E> addState) {
+        Set<ElementState<E>> removes = Operations.filtered(removeSet.lookup(),
+                new Operations.Predicate<ElementState<E>>() {
+                    @Override
+                    public boolean call(ElementState<E> element) {
+                        return element.getElement().equals(addState.getElement())
+                                && element.getTag().equals(addState.getTag());
+                    }
+                });
         return removes.isEmpty();
     }
 

--- a/src/main/java/io/dmitryivanov/crdt/OURSet.java
+++ b/src/main/java/io/dmitryivanov/crdt/OURSet.java
@@ -102,7 +102,7 @@ public class OURSet<E extends Comparable<E>> {
                 new Operations.Predicate2<ElementState<E>, ElementState<E>>() {
                     @Override
                     public boolean call(ElementState<E> first, ElementState<E> second) {
-                        return first.compareTo(second) >= 0;
+                        return first.compareTo(second) < 0;
                     }
                 });
         rest.add(winner);

--- a/src/main/java/io/dmitryivanov/crdt/OURSet.java
+++ b/src/main/java/io/dmitryivanov/crdt/OURSet.java
@@ -118,7 +118,7 @@ public class OURSet<E extends Comparable<E>> {
         final Set<ElementState<E>> union = Operations.union(elements, anotherOURSet.getElements());
 
         // group by elements id
-        final Map<UUID, Collection<ElementState<E>>> index = Operations.toListMap(union, new Operations.Mapper<ElementState<E>, UUID>() {
+        final Map<UUID, Collection<ElementState<E>>> index = Operations.groupBy(union, new Operations.Mapper<ElementState<E>, UUID>() {
             @Override
             public UUID call(ElementState<E> element) {
                 return element.id;

--- a/src/main/java/io/dmitryivanov/crdt/TwoPSet.java
+++ b/src/main/java/io/dmitryivanov/crdt/TwoPSet.java
@@ -24,10 +24,11 @@
 
 package io.dmitryivanov.crdt;
 
+import io.dmitryivanov.crdt.helpers.Operations;
+
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public class TwoPSet<E> {
 
@@ -54,7 +55,7 @@ public class TwoPSet<E> {
     }
 
     public Set<E> lookup() {
-        Set<E> resultSet = addSet.lookup().stream().filter(e -> !removeSet.lookup().contains(e)).collect(Collectors.toSet());
+        Set<E> resultSet = Operations.diff(addSet.lookup(), removeSet.lookup());
         return Collections.unmodifiableSet(resultSet);
     }
 
@@ -74,7 +75,7 @@ public class TwoPSet<E> {
     }
 
     private Set<E> diff(HashSet<E> firstSet, HashSet<E> secondSet) {
-        return firstSet.stream().filter(e -> !secondSet.contains(e)).collect(Collectors.toSet());
+        return Operations.diff(firstSet, secondSet);
     }
 
     // Visible for testing

--- a/src/main/java/io/dmitryivanov/crdt/helpers/ComparisonChain.java
+++ b/src/main/java/io/dmitryivanov/crdt/helpers/ComparisonChain.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright (C) 2009 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dmitryivanov.crdt.helpers;
+
+import javax.annotation.Nullable;
+
+import java.util.Comparator;
+
+/**
+ * A utility for performing a chained comparison statement. For example:
+ * <pre>   {@code
+ *
+ *   public int compareTo(Foo that) {
+ *     return ComparisonChain.start()
+ *         .compare(this.aString, that.aString)
+ *         .compare(this.anInt, that.anInt)
+ *         .compare(this.anEnum, that.anEnum, Ordering.natural().nullsLast())
+ *         .result();
+ *   }}</pre>
+ *
+ * <p>The value of this expression will have the same sign as the <i>first
+ * nonzero</i> comparison result in the chain, or will be zero if every
+ * comparison result was zero.
+ *
+ * <p><b>Note:</b> {@code ComparisonChain} instances are <b>immutable</b>. For
+ * this utility to work correctly, calls must be chained as illustrated above.
+ *
+ * <p>Performance note: Even though the {@code ComparisonChain} caller always
+ * invokes its {@code compare} methods unconditionally, the {@code
+ * ComparisonChain} implementation stops calling its inputs' {@link
+ * Comparable#compareTo compareTo} and {@link Comparator#compare compare}
+ * methods as soon as one of them returns a nonzero result. This optimization is
+ * typically important only in the presence of expensive {@code compareTo} and
+ * {@code compare} implementations.
+ *
+ * <p>See the Guava User Guide article on <a href=
+ * "https://github.com/google/guava/wiki/CommonObjectUtilitiesExplained#comparecompareto">
+ * {@code ComparisonChain}</a>.
+ *
+ * @author Mark Davis
+ * @author Kevin Bourrillion
+ * @since 2.0
+ */
+public abstract class ComparisonChain {
+  private ComparisonChain() {}
+
+  /**
+   * Begins a new chained comparison statement. See example in the class
+   * documentation.
+   */
+  public static ComparisonChain start() {
+    return ACTIVE;
+  }
+
+  private static final ComparisonChain ACTIVE =
+      new ComparisonChain() {
+        @SuppressWarnings("unchecked")
+        @Override
+        public ComparisonChain compare(Comparable left, Comparable right) {
+          return classify(left.compareTo(right));
+        }
+
+        @Override
+        public <T> ComparisonChain compare(
+                @Nullable T left, @Nullable T right, Comparator<T> comparator) {
+          return classify(comparator.compare(left, right));
+        }
+
+        @Override
+        public ComparisonChain compare(int left, int right) {
+          return classify(Primitives.compare(left, right));
+        }
+
+        @Override
+        public ComparisonChain compare(long left, long right) {
+          return classify(Primitives.compare(left, right));
+        }
+
+        @Override
+        public ComparisonChain compare(float left, float right) {
+          return classify(Float.compare(left, right));
+        }
+
+        @Override
+        public ComparisonChain compare(double left, double right) {
+          return classify(Double.compare(left, right));
+        }
+
+        @Override
+        public ComparisonChain compareTrueFirst(boolean left, boolean right) {
+          return classify(Primitives.compare(right, left)); // reversed
+        }
+
+        @Override
+        public ComparisonChain compareFalseFirst(boolean left, boolean right) {
+          return classify(Primitives.compare(left, right));
+        }
+
+        ComparisonChain classify(int result) {
+          return (result < 0) ? LESS : (result > 0) ? GREATER : ACTIVE;
+        }
+
+        @Override
+        public int result() {
+          return 0;
+        }
+      };
+
+  private static final ComparisonChain LESS = new InactiveComparisonChain(-1);
+
+  private static final ComparisonChain GREATER = new InactiveComparisonChain(1);
+
+  private static final class InactiveComparisonChain extends ComparisonChain {
+    final int result;
+
+    InactiveComparisonChain(int result) {
+      this.result = result;
+    }
+
+    @Override
+    public ComparisonChain compare(@Nullable Comparable left, @Nullable Comparable right) {
+      return this;
+    }
+
+    @Override
+    public <T> ComparisonChain compare(
+        @Nullable T left, @Nullable T right, @Nullable Comparator<T> comparator) {
+      return this;
+    }
+
+    @Override
+    public ComparisonChain compare(int left, int right) {
+      return this;
+    }
+
+    @Override
+    public ComparisonChain compare(long left, long right) {
+      return this;
+    }
+
+    @Override
+    public ComparisonChain compare(float left, float right) {
+      return this;
+    }
+
+    @Override
+    public ComparisonChain compare(double left, double right) {
+      return this;
+    }
+
+    @Override
+    public ComparisonChain compareTrueFirst(boolean left, boolean right) {
+      return this;
+    }
+
+    @Override
+    public ComparisonChain compareFalseFirst(boolean left, boolean right) {
+      return this;
+    }
+
+    @Override
+    public int result() {
+      return result;
+    }
+  }
+
+  /**
+   * Compares two comparable objects as specified by {@link
+   * Comparable#compareTo}, <i>if</i> the result of this comparison chain
+   * has not already been determined.
+   */
+  public abstract ComparisonChain compare(Comparable<?> left, Comparable<?> right);
+
+  /**
+   * Compares two objects using a comparator, <i>if</i> the result of this
+   * comparison chain has not already been determined.
+   */
+  public abstract <T> ComparisonChain compare(
+      @Nullable T left, @Nullable T right, Comparator<T> comparator);
+
+  /**
+   * Compares two {@code int} values as specified by {@link Primitives#compare},
+   * <i>if</i> the result of this comparison chain has not already been
+   * determined.
+   */
+  public abstract ComparisonChain compare(int left, int right);
+
+  /**
+   * Compares two {@code long} values as specified by {@link Primitives#compare},
+   * <i>if</i> the result of this comparison chain has not already been
+   * determined.
+   */
+  public abstract ComparisonChain compare(long left, long right);
+
+  /**
+   * Compares two {@code float} values as specified by {@link
+   * Float#compare}, <i>if</i> the result of this comparison chain has not
+   * already been determined.
+   */
+  public abstract ComparisonChain compare(float left, float right);
+
+  /**
+   * Compares two {@code double} values as specified by {@link
+   * Double#compare}, <i>if</i> the result of this comparison chain has not
+   * already been determined.
+   */
+  public abstract ComparisonChain compare(double left, double right);
+
+  /**
+   * Discouraged synonym for {@link #compareFalseFirst}.
+   *
+   * @deprecated Use {@link #compareFalseFirst}; or, if the parameters passed
+   *     are being either negated or reversed, undo the negation or reversal and
+   *     use {@link #compareTrueFirst}.
+   * @since 19.0
+   */
+  @Deprecated
+  public final ComparisonChain compare(Boolean left, Boolean right) {
+    return compareFalseFirst(left, right);
+  }
+
+  /**
+   * Compares two {@code boolean} values, considering {@code true} to be less
+   * than {@code false}, <i>if</i> the result of this comparison chain has not
+   * already been determined.
+   *
+   * @since 12.0
+   */
+  public abstract ComparisonChain compareTrueFirst(boolean left, boolean right);
+
+  /**
+   * Compares two {@code boolean} values, considering {@code false} to be less
+   * than {@code true}, <i>if</i> the result of this comparison chain has not
+   * already been determined.
+   *
+   * @since 12.0 (present as {@code compare} since 2.0)
+   */
+  public abstract ComparisonChain compareFalseFirst(boolean left, boolean right);
+
+  /**
+   * Ends this comparison chain and returns its result: a value having the
+   * same sign as the first nonzero comparison result in the chain, or zero if
+   * every result was zero.
+   */
+  public abstract int result();
+}

--- a/src/main/java/io/dmitryivanov/crdt/helpers/Operations.java
+++ b/src/main/java/io/dmitryivanov/crdt/helpers/Operations.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) pakoito 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package io.dmitryivanov.crdt.helpers;
 

--- a/src/main/java/io/dmitryivanov/crdt/helpers/Operations.java
+++ b/src/main/java/io/dmitryivanov/crdt/helpers/Operations.java
@@ -18,12 +18,10 @@ public final class Operations {
     }
 
     public static <E> Set<E> union(Set<E> firstSet, final Set<E> secondSet) {
-        return filtered(firstSet, new Predicate<E>() {
-            @Override
-            public boolean call(E element) {
-                return secondSet.contains(element);
-            }
-        });
+        final Set<E> newSet = new HashSet<>();
+        newSet.addAll(firstSet);
+        newSet.addAll(secondSet);
+        return newSet;
     }
 
     public static <E> Set<E> filtered(Set<E> set, Predicate<E> predicate) {

--- a/src/main/java/io/dmitryivanov/crdt/helpers/Operations.java
+++ b/src/main/java/io/dmitryivanov/crdt/helpers/Operations.java
@@ -73,7 +73,7 @@ public final class Operations {
         return winner;
     }
 
-    public static <K, V> Map<K, Collection<V>> toListMap(Set<V> map, Mapper<V, K> mapper) {
+    public static <K, V> Map<K, Collection<V>> groupBy(Collection<V> map, Mapper<V, K> mapper) {
         final Map<K, Collection<V>> newMap = new HashMap<>(map.size());
         for (V element : map) {
             K key = mapper.call(element);

--- a/src/main/java/io/dmitryivanov/crdt/helpers/Operations.java
+++ b/src/main/java/io/dmitryivanov/crdt/helpers/Operations.java
@@ -1,0 +1,96 @@
+
+package io.dmitryivanov.crdt.helpers;
+
+import java.util.*;
+
+public final class Operations {
+    private Operations() {
+        // No instances
+    }
+
+    public static <E> Set<E> diff(Set<E> firstSet, final Set<E> secondSet) {
+        return filtered(firstSet, new Predicate<E>() {
+            @Override
+            public boolean call(E element) {
+                return !secondSet.contains(element);
+            }
+        });
+    }
+
+    public static <E> Set<E> union(Set<E> firstSet, final Set<E> secondSet) {
+        return filtered(firstSet, new Predicate<E>() {
+            @Override
+            public boolean call(E element) {
+                return secondSet.contains(element);
+            }
+        });
+    }
+
+    public static <E> Set<E> filtered(Set<E> set, Predicate<E> predicate) {
+        final Set<E> newSet = new HashSet<>();
+        for (E element : set) {
+            if (predicate.call(element)) {
+                newSet.add(element);
+            }
+        }
+        return newSet;
+    }
+
+    public static <E, R> Set<R> filteredAndMapped(Set<E> set, Predicate<E> predicate,
+            Mapper<E, R> mapper) {
+        final Set<R> newSet = new HashSet<>();
+        for (E element : set) {
+            if (predicate.call(element)) {
+                newSet.add(mapper.call(element));
+            }
+        }
+        return newSet;
+    }
+
+    public static <E> E select(Set<E> set, Predicate2<E, E> predicate) {
+        if (set.isEmpty()) {
+            throw new IllegalArgumentException("Empty set for select operation");
+        }
+        E winner = set.iterator().next();
+        for (E element : set) {
+            if (predicate.call(winner, element)) {
+                winner = element;
+            }
+        }
+        return winner;
+    }
+
+    public static <K, V> Map<K, Collection<V>> toListMap(Set<V> map, Mapper<V, K> mapper) {
+        final Map<K, Collection<V>> newMap = new HashMap<>(map.size());
+        for (V element : map) {
+            K key = mapper.call(element);
+            Collection<V> list = newMap.get(key);
+            if (null == list) {
+                list = new ArrayList<>();
+            }
+            list.add(element);
+            newMap.put(key, list);
+        }
+        return newMap;
+    }
+
+    public static <K, V, R> Map<K, R> mapValues(Map<K, V> map, Mapper<V, R> mapper) {
+        final Map<K, R> newMap = new HashMap<>(map.size());
+        for (Map.Entry<K, V> entry : map.entrySet()) {
+            newMap.put(entry.getKey(), mapper.call(entry.getValue()));
+        }
+        return newMap;
+    }
+
+    public interface Predicate<E> {
+        boolean call(E element);
+    }
+
+    public interface Predicate2<E, F> {
+        boolean call(E first, F second);
+    }
+
+    public interface Mapper<E, R> {
+        R call(E element);
+    }
+}

--- a/src/main/java/io/dmitryivanov/crdt/helpers/Primitives.java
+++ b/src/main/java/io/dmitryivanov/crdt/helpers/Primitives.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2008 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.dmitryivanov.crdt.helpers;
+
+public final class Primitives {
+    private Primitives() {
+        // No instances
+    }
+
+    /**
+     * Compares the two specified {@code boolean} values in the standard way ({@code false} is
+     * considered less than {@code true}). The sign of the value returned is the same as that of
+     * {@code ((Boolean) a).compareTo(b)}.
+     * <p>
+     * <b>Note for Java 7 and later:</b> this method should be treated as deprecated; use the
+     * equivalent {@link Boolean#compare} method instead.
+     *
+     * @param a the first {@code boolean} to compare
+     * @param b the second {@code boolean} to compare
+     * @return a positive number if only {@code a} is {@code true}, a negative number if only
+     *         {@code b} is true, or zero if {@code a == b}
+     */
+    public static int compare(boolean a, boolean b) {
+        return (a == b) ? 0 : (a ? 1 : -1);
+    }
+
+    /**
+     * Compares the two specified {@code int} values. The sign of the value returned is the same as
+     * that of {@code ((Integer) a).compareTo(b)}.
+     *
+     * <p><b>Note for Java 7 and later:</b> this method should be treated as deprecated; use the
+     * equivalent {@link Integer#compare} method instead.
+     *
+     * @param a the first {@code int} to compare
+     * @param b the second {@code int} to compare
+     * @return a negative value if {@code a} is less than {@code b}; a positive value if {@code a} is
+     *     greater than {@code b}; or zero if they are equal
+     */
+    public static int compare(int a, int b) {
+        return (a < b) ? -1 : ((a > b) ? 1 : 0);
+    }
+
+    /**
+     * Compares the two specified {@code long} values. The sign of the value returned is the same as
+     * that of {@code ((Long) a).compareTo(b)}.
+     *
+     * <p><b>Note for Java 7 and later:</b> this method should be treated as deprecated; use the
+     * equivalent {@link Long#compare} method instead.
+     *
+     * @param a the first {@code long} to compare
+     * @param b the second {@code long} to compare
+     * @return a negative value if {@code a} is less than {@code b}; a positive value if {@code a} is
+     *     greater than {@code b}; or zero if they are equal
+     */
+    public static int compare(long a, long b) {
+        return (a < b) ? -1 : ((a > b) ? 1 : 0);
+    }
+}


### PR DESCRIPTION
This branch removes all dependencies on Java 8 Streams and Guava. Both dependencies are not Android happy.

Replacements have been either copied from the Guava repository (ComparisonChain.java, Primitives.java) or manually rewritten (Operations.java). OURSet's merge may require some better tests before merging, as the process was awfully specific and required reproducing ListMultiMap's behaviour.

On the way some immutable collections from Guava are lost, but given that they're isolated in the library and only used as tooling it should be okay.
